### PR TITLE
Change edit bridging messages

### DIFF
--- a/bridge/discord.go
+++ b/bridge/discord.go
@@ -134,7 +134,6 @@ func (d *discordBot) publishMessage(s *discordgo.Session, m *discordgo.Message, 
 			content = "/me " + content
 		}
 
-		isAction = true
 		content = "[edit]: " + content
 	}
 

--- a/bridge/discord.go
+++ b/bridge/discord.go
@@ -135,7 +135,7 @@ func (d *discordBot) publishMessage(s *discordgo.Session, m *discordgo.Message, 
 		}
 
 		isAction = true
-		content = "meant to say \"" + content + "\""
+		content = "[edit]: " + content
 	}
 
 	pmTarget := ""


### PR DESCRIPTION
When a Discord user edited their message multiple time, it would spit out a large amount of spam into IRC about their new messages. This was particularly bad when multiple edits had happened in quick succession with very little difference in each new message.

With this change, edited messages are now prepended with `[edit]` rather than turned into an action, saying 'meant to say'.

Closes #29.