### PR TITLE
Add the config flag 'no_tls' and the run parameter --no-tls

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -22,6 +22,9 @@ type Config struct {
 	WebIRCPass       string
 	NickServIdentify string // string: "[account] password"
 
+	// NoTLS constrols whether to use TLS at all when connecting to the IRC server
+	NoTLS bool
+
 	// InsecureSkipVerify controls whether a client verifies the
 	// server's certificate chain and host name.
 	// If InsecureSkipVerify is true, TLS accepts any certificate
@@ -264,9 +267,11 @@ func rejoinIRC(con *irc.Connection, event *irc.Event) {
 // SetupIRCConnection sets up an IRC connection with config settings like
 // UseTLS, InsecureSkipVerify, and WebIRCPass.
 func (b *Bridge) SetupIRCConnection(con *irc.Connection, hostname, ip string) {
-	con.UseTLS = true
-	con.TLSConfig = &tls.Config{
-		InsecureSkipVerify: b.Config.InsecureSkipVerify,
+	if !b.Config.NoTLS {
+		con.UseTLS = true
+		con.TLSConfig = &tls.Config{
+			InsecureSkipVerify: b.Config.InsecureSkipVerify,
+		}
 	}
 	con.AddCallback("KICK", func(e *irc.Event) {
 		rejoinIRC(con, e)

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,6 @@
 discord_token: abc.def.ghi
 irc_server: localhost:6697
+no_tls: false # this requires restart
 guild_id: 315277951597936640
 nickserv_identify: password123
 channel_mappings:

--- a/main.go
+++ b/main.go
@@ -20,7 +20,8 @@ func main() {
 	config := flag.String("config", "", "Config file to read configuration stuff from")
 	simple := flag.Bool("simple", false, "When in simple mode, the bridge will only spawn one IRC connection for listening and speaking")
 	debugMode := flag.Bool("debug", false, "Debug mode? (false = use value from settings)")
-	insecure := flag.Bool("insecure", false, "Skip TLS verification? (INSECURE MODE) (false = use value from settings)")
+	no_tls := flag.Bool("no-tls", false, "Avoids using TLS att all when connecting to IRC server ")
+	insecure := flag.Bool("insecure", false, "Skip TLS certificate verification? (INSECURE MODE) (false = use value from settings)")
 
 	flag.Parse()
 
@@ -64,6 +65,9 @@ func main() {
 		*debugMode = viper.GetBool("debug")
 	}
 	//
+	if !*no_tls {
+		*no_tls = viper.GetBool("no_tls")
+	}
 	if !*insecure {
 		*insecure = viper.GetBool("insecure")
 	}
@@ -98,6 +102,7 @@ func main() {
 		NickServIdentify:   identify,
 		WebIRCPass:         webIRCPass,
 		Debug:              *debugMode,
+		NoTLS:              *no_tls,
 		InsecureSkipVerify: *insecure,
 		Suffix:             suffix,
 		SimpleMode:         *simple,


### PR DESCRIPTION
This flag skips using TLS when connecting to the IRC server

Fixes #36 