### PR TITLE
Initial Single Discord User Support

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -16,6 +16,7 @@ import (
 // Config to be passed to New
 type Config struct {
 	DiscordBotToken, GuildID string
+	DiscordSingleUser        bool // Relay all messages via the bot instead of fake usernames if true
 
 	// Map from Discord to IRC
 	ChannelMappings map[string]string

--- a/bridge/irc_listener.go
+++ b/bridge/irc_listener.go
@@ -1,6 +1,7 @@
 package bridge
 
 import (
+	"fmt"
 	"strings"
 
 	ircf "github.com/qaisjp/go-discord-irc/irc/format"
@@ -214,10 +215,18 @@ func (i *ircListener) OnPrivateMessage(e *irc.Event) {
 	msg = ircf.BlocksToMarkdown(ircf.Parse(ircf.StripColor(msg)))
 
 	go func(e *irc.Event) {
-		i.bridge.discordMessagesChan <- IRCMessage{
-			IRCChannel: e.Arguments[0],
-			Username:   e.Nick,
-			Message:    msg,
+		if !i.bridge.Config.DiscordSingleUser {
+			i.bridge.discordMessagesChan <- IRCMessage{
+				IRCChannel: e.Arguments[0],
+				Username:   e.Nick,
+				Message:    msg,
+			}
+		} else {
+			i.bridge.discordMessagesChan <- IRCMessage{
+				IRCChannel: e.Arguments[0],
+				Username:   "",
+				Message:    fmt.Sprintf("**%s** %s", e.Nick, msg),
+			}
 		}
 	}(e)
 }

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,6 @@
 ---
 discord_token: abc.def.ghi
+#discord_single_user: true
 irc_server: localhost:6697
 guild_id: 315277951597936640
 nickserv_identify: password123

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 		log.Fatalln(errors.Wrap(err, "could not read config"))
 	}
 
+	discordSingleUser := viper.GetBool("discord_single_user")
 	discordBotToken := viper.GetString("discord_token")             // Discord Bot User Token
 	channelMappings := viper.GetStringMapString("channel_mappings") // Discord:IRC mappings in format '#discord1:#irc1,#discord2:#irc2,...'
 	ircServer := viper.GetString("irc_server")                      // Server address to use, example `irc.freenode.net:7000`.
@@ -116,6 +117,7 @@ func main() {
 
 	dib, err := bridge.New(&bridge.Config{
 		DiscordBotToken:    discordBotToken,
+		DiscordSingleUser:  discordSingleUser,
 		GuildID:            guildID,
 		IRCListenerName:    ircUsername,
 		IRCServer:          ircServer,
@@ -177,6 +179,7 @@ func main() {
 			SetLogDebug(debug)
 		}
 
+		dib.Config.DiscordSingleUser = viper.GetBool("discord_single_user")
 		chans := viper.GetStringMapString("channel_mappings")
 		equalChans := reflect.DeepEqual(chans, channelMappings)
 		if !equalChans {


### PR DESCRIPTION
Allows for all messages relayed to Discord to be via the bot's nick instead of generated usernames per IRC Nick that talks.

This also gets around if you can't use/find an avatar API that looks as you would wish it to (the current one in the example config doesn't work, Discord expects PNG and the API returns SVG).