### PR TITLE
Better Puppet Detection

### DIFF
--- a/bridge/irc_listener.go
+++ b/bridge/irc_listener.go
@@ -65,7 +65,7 @@ func (i *ircListener) OnJoinQuitSettingChange() {
 	// Clear Nicktrack QUIT callback as it races with this
 	i.ClearCallback("QUIT")
 	i.ClearCallback("NICK")
-	i.AddCallback("NICK", i.nickTrackQuit)
+	i.AddCallback("NICK", i.nickTrackNick)
 
 	// If remove callbacks...
 	if !i.bridge.Config.ShowJoinQuit {

--- a/bridge/irc_listener.go
+++ b/bridge/irc_listener.go
@@ -45,6 +45,15 @@ func newIRCListener(dib *Bridge, webIRCPass string) *ircListener {
 	return listener
 }
 
+func (i *ircListener) nickTrackNick(event *irc.Event) {
+	oldNick := event.Nick
+	newNick := event.Message()
+	if con, ok := i.bridge.ircManager.puppetNicks[oldNick]; ok {
+		i.bridge.ircManager.puppetNicks[newNick] = con
+		delete(i.bridge.ircManager.puppetNicks, oldNick)
+	}
+}
+
 // From irc_nicktrack.go.
 func (i *ircListener) nickTrackQuit(e *irc.Event) {
 	for k := range i.Connection.Channels {
@@ -55,6 +64,8 @@ func (i *ircListener) nickTrackQuit(e *irc.Event) {
 func (i *ircListener) OnJoinQuitSettingChange() {
 	// Clear Nicktrack QUIT callback as it races with this
 	i.ClearCallback("QUIT")
+	i.ClearCallback("NICK")
+	i.AddCallback("NICK", i.nickTrackQuit)
 
 	// If remove callbacks...
 	if !i.bridge.Config.ShowJoinQuit {
@@ -177,7 +188,10 @@ func (i *ircListener) OnJoinChannel(e *irc.Event) {
 }
 
 func (i *ircListener) isPuppetNick(nick string) bool {
-	return nick == i.bridge.Config.IRCListenerName || strings.HasSuffix(strings.TrimRight(nick, "_"), i.bridge.Config.Suffix)
+	if _, ok := i.bridge.ircManager.puppetNicks[nick]; ok {
+		return true
+	}
+	return false
 }
 
 func (i *ircListener) OnPrivateMessage(e *irc.Event) {

--- a/bridge/irc_manager.go
+++ b/bridge/irc_manager.go
@@ -19,7 +19,7 @@ var DevMode = false
 // IRCManager should only be used from one thread.
 type IRCManager struct {
 	ircConnections map[string]*ircConnection
-	discordNicks   map[string]*ircConnection
+	puppetNicks    map[string]*ircConnection
 
 	bridge *Bridge
 }
@@ -28,7 +28,7 @@ type IRCManager struct {
 func newIRCManager(bridge *Bridge) *IRCManager {
 	return &IRCManager{
 		ircConnections: make(map[string]*ircConnection),
-		discordNicks:   make(map[string]*ircConnection),
+		puppetNicks:    make(map[string]*ircConnection),
 		bridge:         bridge,
 	}
 }

--- a/bridge/irc_manager.go
+++ b/bridge/irc_manager.go
@@ -19,6 +19,7 @@ var DevMode = false
 // IRCManager should only be used from one thread.
 type IRCManager struct {
 	ircConnections map[string]*ircConnection
+	discordNicks   map[string]*ircConnection
 
 	bridge *Bridge
 }
@@ -27,6 +28,7 @@ type IRCManager struct {
 func newIRCManager(bridge *Bridge) *IRCManager {
 	return &IRCManager{
 		ircConnections: make(map[string]*ircConnection),
+		discordNicks:   make(map[string]*ircConnection),
 		bridge:         bridge,
 	}
 }
@@ -197,6 +199,7 @@ func (m *IRCManager) HandleUser(user DiscordUser) {
 	con.innerCon.AddCallback("PRIVMSG", con.OnPrivateMessage)
 
 	m.ircConnections[user.ID] = con
+	m.puppetNicks[nick] = con
 
 	if DevMode {
 		fmt.Println("Incrementing total connections. It's now", len(m.ircConnections))


### PR DESCRIPTION
Detect puppets by our creating them vs by nick suffixing. Not fool-proof at the moment as when/if an ircd forces a nick change before the listener sees it as the old nick it'll be a hanging nick and could double-ups or loops.

Assuming someone is already using nick suffixes this should work just like it did before but would likely fix #43 and fix #44.

Will look into improving it to handle the above noted error condition "soon".