### PR TITLE
Add format options relay nick changes fix

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -28,6 +28,9 @@ type Config struct {
 	NickServIdentify string // string: "[account] password"
 	PuppetUsername   string // Username to connect to IRC with
 
+	DiscordFormat map[string]string // formatting for non-PRIVMSG relays from IRC to Discord
+	IRCFormat     string            // format for messages relayed in simple mode
+
 	// NoTLS constrols whether to use TLS at all when connecting to the IRC server
 	NoTLS bool
 

--- a/bridge/irc_listener.go
+++ b/bridge/irc_listener.go
@@ -74,10 +74,16 @@ func userOnChannelFix(user string, channel irc.Channel) bool {
 
 func (i *ircListener) OnNickRelayToDiscord(event *irc.Event) {
 	newNick := event.Message()
+	message := i.bridge.ircManager.formatDiscordMessage(event.Code, event, newNick, "")
+
+	// if the message is empty...
+	if message == "" {
+		return // do nothing, Discord doesn't like empty messages anyway
+	}
 
 	msg := IRCMessage{
 		Username: "",
-		Message:  i.bridge.ircManager.formatDiscordMessage(event.Code, event, newNick, ""),
+		Message:  message,
 	}
 
 	for _, m := range i.bridge.mappings {

--- a/bridge/irc_manager.go
+++ b/bridge/irc_manager.go
@@ -323,6 +323,15 @@ func (m *IRCManager) generateNickname(discord DiscordUser) string {
 	return newNick
 }
 
+func (m *IRCManager) formatIRCMessage(message *DiscordMessage, content string) string {
+	msg := m.bridge.Config.IRCFormat
+	length := len(message.Author.Username)
+	msg = strings.ReplaceAll(msg, "${USER}", message.Author.Username[:1]+"\u200B"+message.Author.Username[1:length])
+	msg = strings.ReplaceAll(msg, "${DISCRIMINATOR}", message.Author.Discriminator)
+	msg = strings.ReplaceAll(msg, "${CONTENT}", content)
+	return msg
+}
+
 // SendMessage sends a broken down Discord Message to a particular IRC channel.
 func (m *IRCManager) SendMessage(channel string, msg *DiscordMessage) {
 	con, ok := m.ircConnections[msg.Author.ID]
@@ -333,14 +342,16 @@ func (m *IRCManager) SendMessage(channel string, msg *DiscordMessage) {
 
 	// Person is appearing offline (or the bridge is running in Simple Mode)
 	if !ok {
-		length := len(msg.Author.Username)
+		// length := len(msg.Author.Username)
 		for _, line := range strings.Split(content, "\n") {
-			m.bridge.ircListener.Privmsg(channel, fmt.Sprintf(
-				"<%s#%s> %s",
-				msg.Author.Username[:1]+"\u200B"+msg.Author.Username[1:length],
-				msg.Author.Discriminator,
-				line,
-			))
+			// m.bridge.ircListener.Privmsg(channel, fmt.Sprintf(
+			// 	"<%s#%s> %s",
+			// 	msg.Author.Username[:1]+"\u200B"+msg.Author.Username[1:length],
+			// 	msg.Author.Discriminator,
+			// 	line,
+			// ))
+
+			m.bridge.ircListener.Privmsg(channel, m.formatIRCMessage(msg, line))
 		}
 		return
 	}

--- a/bridge/irc_manager.go
+++ b/bridge/irc_manager.go
@@ -385,6 +385,22 @@ func (m *IRCManager) SendMessage(channel string, msg *DiscordMessage) {
 	}
 }
 
+func (m *IRCManager) formatDiscordMessage(msgFormat string, e *irc.Event, content string, target string) string {
+	msg := ""
+	if format, ok := m.bridge.Config.DiscordFormat[strings.ToLower(msgFormat)]; ok && format != "" {
+		msg = format
+		msg = strings.ReplaceAll(msg, "${NICK}", e.Nick)
+		msg = strings.ReplaceAll(msg, "${IDENT}", e.User)
+		msg = strings.ReplaceAll(msg, "${HOST}", e.Host)
+		msg = strings.ReplaceAll(msg, "${CONTENT}", content)
+		msg = strings.ReplaceAll(msg, "${TARGET}", target)
+	} // else {
+	//	 should we warn?
+	//}
+
+	return msg
+}
+
 // RequestChannels finds all the Discord channels this user belongs to,
 // and then find pairings in the global pairings list
 // Currently just returns all participating IRC channels

--- a/main.go
+++ b/main.go
@@ -83,6 +83,17 @@ func main() {
 	viper.SetDefault("avatar_url", "https://ui-avatars.com/api/?name=${USERNAME}")
 	avatarURL := viper.GetString("avatar_url")
 	//
+	viper.SetDefault("discord_format", map[string]string{
+		"JOIN": "_${NICK} joined (${IDENT}@${HOST})_",
+		"PART": "_${NICK} left (${IDENT}@${HOST}) - ${CONTENT}_",
+		"QUIT": "_${NICK} quit (${IDENT}@${HOST}) - Quit: ${CONTENT}_",
+		"KICK": "_${TARGET} was kicked by ${NICK} - ${CONTENT}_",
+	})
+	discordFormat := viper.GetStringMapString("discord_format")
+	//
+	viper.SetDefault("irc_format", "<${USER}#${DISCRIMINATOR}> ${CONTENT}")
+	ircFormat := viper.GetString("irc_format")
+	//
 	viper.SetDefault("irc_listener_name", "~d")
 	ircUsername := viper.GetString("irc_listener_name") // Name for IRC-side bot, for listening to messages.
 	// Name to Connect to IRC puppet account with
@@ -120,7 +131,9 @@ func main() {
 	dib, err := bridge.New(&bridge.Config{
 		AvatarURL:          avatarURL,
 		DiscordBotToken:    discordBotToken,
+		DiscordFormat:      discordFormat,
 		GuildID:            guildID,
+		IRCFormat:          ircFormat,
 		IRCListenerName:    ircUsername,
 		IRCServer:          ircServer,
 		IRCServerPass:      ircPassword,


### PR DESCRIPTION
This depends on #72 and #76.

Integrates support for PM's with the formatting options so that way they can have a way of being formatted as well.

Figure that all single-sourced messages (JOIN/PART/QUIT (PM via #75 and formatting for PM via #78) relayed towards Discord should have a way to format it.

Still pending figuring out best way to document this in `README.md`.