### PR TITLE
Fix listener puppet detection

### DIFF
--- a/bridge/irc_listener.go
+++ b/bridge/irc_listener.go
@@ -188,6 +188,9 @@ func (i *ircListener) OnJoinChannel(e *irc.Event) {
 }
 
 func (i *ircListener) isPuppetNick(nick string) bool {
+	if i.GetNick() == nick {
+		return true
+	}
 	if _, ok := i.bridge.ircManager.puppetNicks[nick]; ok {
 		return true
 	}


### PR DESCRIPTION
We now detect our listener as a puppet to (halts displays of it joining channels when JOIN/PART/QUIT is set to be shown).
Pretty self explanatory.