### PR TITLE
Mention roles & channels

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -58,6 +58,9 @@ type Config struct {
 	// Maximum Nicklength for irc server
 	MaxNickLength int
 
+	// Disabling this field is disabling @everyone and @here by inserting an invisible whitespace
+	AllowMentionEveryone bool
+
 	Debug         bool
 	DebugPresence bool
 }
@@ -415,8 +418,10 @@ func (b *Bridge) loop() {
 			})
 
 			// Replace everyone and here - https://git.io/Je1yi
-			content = strings.ReplaceAll(content, "@everyone", "@\u200beveryone")
-			content = strings.ReplaceAll(content, "@here", "@\u200bhere")
+			if b.Config.AllowMentionEveryone {
+				content = strings.ReplaceAll(content, "@everyone", "@\u200beveryone")
+				content = strings.ReplaceAll(content, "@here", "@\u200bhere")
+			}
 
 			if username == "" {
 				// System messages come straight from the bot

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -60,6 +60,8 @@ type Config struct {
 
 	// Disabling this field is disabling @everyone and @here by inserting an invisible whitespace
 	AllowMentionEveryone bool
+	AllowMentionRoles    bool
+	AllowMentionChannels bool
 
 	Debug         bool
 	DebugPresence bool

--- a/config.yml
+++ b/config.yml
@@ -23,6 +23,8 @@ cooldown_duration: 86400 # optional, default 86400 (24 hours), time in seconds f
 max_nick_length: 30 # Maximum Length of a nick allowed
 
 allow_mention_everyone: false # @everyone and @here are disabled by default.
+allow_mention_roles: false # enabling this option enables to convert @role into a Discord mention for the role <role>.
+allow_mention_channels: true # enabling this option enables to convert #channel into a Discord link for the channel #channel.
 
 # You definitely should restart the bridge after changing the following:
 insecure: true

--- a/config.yml
+++ b/config.yml
@@ -24,7 +24,7 @@ max_nick_length: 30 # Maximum Length of a nick allowed
 
 allow_mention_everyone: false # @everyone and @here are disabled by default.
 allow_mention_roles: false # enabling this option enables to convert @role into a Discord mention for the role <role>.
-allow_mention_channels: true # enabling this option enables to convert #channel into a Discord link for the channel #channel.
+allow_mention_channels: false # enabling this option enables to convert #channel into a Discord link for the channel #channel.
 
 # You definitely should restart the bridge after changing the following:
 insecure: true

--- a/config.yml
+++ b/config.yml
@@ -22,6 +22,8 @@ show_joinquit: false # displays JOIN, PART, QUIT, KICK on discord
 cooldown_duration: 86400 # optional, default 86400 (24 hours), time in seconds for a discord user to be offline before it's puppet disconnects from irc
 max_nick_length: 30 # Maximum Length of a nick allowed
 
+allow_mention_everyone: false # @everyone and @here are disabled by default.
+
 # You definitely should restart the bridge after changing the following:
 insecure: true
 no_tls: false

--- a/main.go
+++ b/main.go
@@ -108,6 +108,10 @@ func main() {
 
 	viper.SetDefault("allow_mention_everyone", false)
 	allowMentionEveryone := viper.GetBool("allow_mention_everyone")
+	viper.SetDefault("allow_mention_roles", false)
+	allowMentionRoles := viper.GetBool("allow_mention_roles")
+	viper.SetDefault("allow_mention_channels", false)
+	allowMentionChannels := viper.GetBool("allow_mention_channels")
 
 	if webIRCPass == "" {
 		log.Warnln("webirc_pass is empty")
@@ -141,6 +145,8 @@ func main() {
 		ShowJoinQuit:         showJoinQuit,
 		MaxNickLength:        maxNickLength,
 		AllowMentionEveryone: allowMentionEveryone,
+		AllowMentionRoles:    allowMentionRoles,
+		AllowMentionChannels: allowMentionChannels,
 
 		Debug:         *debugMode,
 		DebugPresence: *debugPresence,

--- a/main.go
+++ b/main.go
@@ -106,6 +106,9 @@ func main() {
 	viper.SetDefault("max_nick_length", ircnick.MAXLENGTH)
 	maxNickLength := viper.GetInt("max_nick_length")
 
+	viper.SetDefault("allow_mention_everyone", false)
+	allowMentionEveryone := viper.GetBool("allow_mention_everyone")
+
 	if webIRCPass == "" {
 		log.Warnln("webirc_pass is empty")
 	}
@@ -118,25 +121,26 @@ func main() {
 	SetLogDebug(*debugMode)
 
 	dib, err := bridge.New(&bridge.Config{
-		AvatarURL:          avatarURL,
-		DiscordBotToken:    discordBotToken,
-		GuildID:            guildID,
-		IRCListenerName:    ircUsername,
-		IRCServer:          ircServer,
-		IRCServerPass:      ircPassword,
-		PuppetUsername:     puppetUsername,
-		NickServIdentify:   identify,
-		WebIRCPass:         webIRCPass,
-		NoTLS:              *notls,
-		InsecureSkipVerify: *insecure,
-		Suffix:             suffix,
-		Separator:          separator,
-		SimpleMode:         *simple,
-		ChannelMappings:    channelMappings,
-		WebhookPrefix:      webhookPrefix,
-		CooldownDuration:   time.Second * time.Duration(cooldownDuration),
-		ShowJoinQuit:       showJoinQuit,
-		MaxNickLength:      maxNickLength,
+		AvatarURL:            avatarURL,
+		DiscordBotToken:      discordBotToken,
+		GuildID:              guildID,
+		IRCListenerName:      ircUsername,
+		IRCServer:            ircServer,
+		IRCServerPass:        ircPassword,
+		PuppetUsername:       puppetUsername,
+		NickServIdentify:     identify,
+		WebIRCPass:           webIRCPass,
+		NoTLS:                *notls,
+		InsecureSkipVerify:   *insecure,
+		Suffix:               suffix,
+		Separator:            separator,
+		SimpleMode:           *simple,
+		ChannelMappings:      channelMappings,
+		WebhookPrefix:        webhookPrefix,
+		CooldownDuration:     time.Second * time.Duration(cooldownDuration),
+		ShowJoinQuit:         showJoinQuit,
+		MaxNickLength:        maxNickLength,
+		AllowMentionEveryone: allowMentionEveryone,
 
 		Debug:         *debugMode,
 		DebugPresence: *debugPresence,


### PR DESCRIPTION
This pull request lets optionally to mention roles and channels through IRC. This also adds an option to mention @everyone and @here.

Issues that can be discussed:
* If the @role is not at the beginning, at the end neither separated by spaces, the role should not be mentioned.
* Roles and channels are queried at each message. We could store locally a copy of all roles/channels.
* The structure of channels of Discord is used for mentions. But we can imagine that if multiple channels are bridged on a same guild, names are updated. For example, if I bridge #irc-a to #discord-a and #irc-b to #discord-b, mentioning #irc-a on IRC should display #discord-a on Discord and reciprocally. This is not obvious, and I don't think that it is really needed.