### PR TITLE
Fix `/me` on Android Discord not going through as CTCP ACTION

### DIFF
--- a/bridge/irc_manager.go
+++ b/bridge/irc_manager.go
@@ -359,7 +359,7 @@ func (m *IRCManager) SendMessage(channel string, msg *DiscordMessage) {
 
 		if strings.HasPrefix(line, "/me ") && len(line) > 4 {
 			ircMessage.IsAction = true
-			ircMessage.Message = line[3:]
+			ircMessage.Message = line[4:]
 		}
 
 		select {

--- a/bridge/irc_manager.go
+++ b/bridge/irc_manager.go
@@ -357,6 +357,11 @@ func (m *IRCManager) SendMessage(channel string, msg *DiscordMessage) {
 			IsAction:   msg.IsAction,
 		}
 
+		if strings.HasPrefix(line, "/me ") && len(line) > 4 {
+			ircMessage.IsAction = true
+			ircMessage.Message = line[3:]
+		}
+
 		select {
 		// Try to send the message immediately
 		case con.messages <- ircMessage:


### PR DESCRIPTION
When a "/me" is issued from a mobile client (android at least, no iOS devices to test) it doesn't get  marked as an action (msg.IsAction != true -> true). This little fix checks the line for a prefix of "/me" and rewrites the `IRCMessage` to be `IsAction: True` and extracts the line data sans "/me".