### PR TITLE
Support for limiting number of connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ The config file is a yaml formatted file with the following fields:
 | `cooldown_duration` | No               | 86400 (24 hours)                               | Yes                          | time in seconds for a discord user to be offline before it's puppet disconnects from irc                                                                                 |
 | `show_joinquit`     | No               | false                                          | yes                          | displays JOIN, PART, QUIT, KICK on discord                                                                                                                               |
 | `max_nick_length`   | No               | 30                                             | yes                          | Maximum allowed nick length                                                                                                                                              |
-| `connection_limit`  | Yes              |                                                | Yes                          | How many connections to IRC (including our listener) to spawn (limit of 0 or less means unlimited)                                                                       |
+| `connection_limit`  | Yes              | 0                                              | Yes                          | How many connections to IRC (including our listener) to spawn (limit of 0 or less means unlimited)                                                                       |
 
 **The filename.yaml file is continuously read from and many changes will
 automatically update on the bridge. This means you can add or remove channels

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ The config file is a yaml formatted file with the following fields:
 | `cooldown_duration` | No               | 86400 (24 hours)                               | Yes                          | time in seconds for a discord user to be offline before it's puppet disconnects from irc                                                                                 |
 | `show_joinquit`     | No               | false                                          | yes                          | displays JOIN, PART, QUIT, KICK on discord                                                                                                                               |
 | `max_nick_length`   | No               | 30                                             | yes                          | Maximum allowed nick length                                                                                                                                              |
+| `connection_limit`  | Yes              |                                                | Yes                          | How many connections to IRC (including our listener) to spawn (limit of 0 or less means unlimited)                                                                       |
 
 **The filename.yaml file is continuously read from and many changes will
 automatically update on the bridge. This means you can add or remove channels

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -17,6 +17,7 @@ import (
 type Config struct {
 	AvatarURL                string
 	DiscordBotToken, GuildID string
+	ConnectionLimit          int // amount of IRC Connections we can spawn
 
 	// Map from Discord to IRC
 	ChannelMappings map[string]string

--- a/bridge/irc_manager.go
+++ b/bridge/irc_manager.go
@@ -154,7 +154,7 @@ func (m *IRCManager) HandleUser(user DiscordUser) {
 	}
 
 	// Don't connect them if we're over our configured connection limit! (Includes our listener)
-	if len(m.ircConnections)+1 >= m.bridge.Config.ConnectionLimit && m.bridge.Config.ConnectionLimit > 0 {
+	if m.bridge.Config.ConnectionLimit > 0 && len(m.ircConnections)+1 >= m.bridge.Config.ConnectionLimit {
 		return
 	}
 

--- a/bridge/irc_manager.go
+++ b/bridge/irc_manager.go
@@ -153,6 +153,11 @@ func (m *IRCManager) HandleUser(user DiscordUser) {
 		}
 	}
 
+	// Don't connect them if we're over our configured connection limit! (Includes our listener)
+	if len(m.ircConnections)+1 >= m.bridge.Config.ConnectionLimit && m.bridge.Config.ConnectionLimit > 0 {
+		return
+	}
+
 	nick := m.generateNickname(user)
 	username := m.generateUsername(user)
 

--- a/config.yml
+++ b/config.yml
@@ -28,5 +28,4 @@ no_tls: false
 debug: false
 webhook_prefix: "(auto-test)"
 # simple: true
-
 # connection_limit: 2 # Would limit this to 2 connections (a listener, and one puppet, the rest relayed)

--- a/config.yml
+++ b/config.yml
@@ -28,3 +28,5 @@ no_tls: false
 debug: false
 webhook_prefix: "(auto-test)"
 # simple: true
+
+# connection_limit: 2 # Would limit this to 2 connections (a listener, and one puppet, the rest relayed)

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ func main() {
 	guildID := viper.GetString("guild_id")                          // Guild to use
 	webIRCPass := viper.GetString("webirc_pass")                    // Password for WEBIRC
 	identify := viper.GetString("nickserv_identify")                // NickServ IDENTIFY for Listener
+	connectionLimit := viper.GetInt("connection_limit")             // Limiter on how many IRC Connections we can spawn
 	//
 	if !*debugMode {
 		*debugMode = viper.GetBool("debug")
@@ -124,6 +125,7 @@ func main() {
 		IRCListenerName:    ircUsername,
 		IRCServer:          ircServer,
 		IRCServerPass:      ircPassword,
+		ConnectionLimit:    connectionLimit,
 		PuppetUsername:     puppetUsername,
 		NickServIdentify:   identify,
 		WebIRCPass:         webIRCPass,


### PR DESCRIPTION
Sometimes the I:Line at a server doesn't allow as many connections as discord users and sometimes we can't use webirc since the IRC server admin may not wish to give us a webirc block - This solves that by allowing one to define an amount of users to allow puppet nicks for and from there on it relays through the listener nick.

~~Note that this is untested and undocumented at this time.~~

**Edit**:
Tested, working, and now documented.