### PR TITLE
Fix race conditions and execution order

### DIFF
--- a/bridge/irc_connection.go
+++ b/bridge/irc_connection.go
@@ -33,13 +33,13 @@ type ircConnection struct {
 
 func (i *ircConnection) GetNick() string {
 	var nick varys.GetNickParams
-	i.manager.varys.GetNick(i.discord.ID, &nick)
+	_ = i.manager.varys.GetNick(i.discord.ID, &nick)
 	return nick.Nick
 }
 
 func (i *ircConnection) Connected() bool {
 	var connected varys.ConnectedParams
-	i.manager.varys.Connected(i.discord.ID, &connected)
+	_ = i.manager.varys.Connected(i.discord.ID, &connected)
 	return connected.Connected
 }
 

--- a/bridge/irc_connection.go
+++ b/bridge/irc_connection.go
@@ -31,6 +31,18 @@ type ircConnection struct {
 	pmNoticedSenders map[string]struct{}
 }
 
+func (i *ircConnection) GetNick() string {
+	var nick string
+	i.manager.varys.GetNick(i.discord.ID, &nick)
+	return nick
+}
+
+func (i *ircConnection) Connected() bool {
+	var connected bool
+	i.manager.varys.Connected(i.discord.ID, &connected)
+	return connected
+}
+
 func (i *ircConnection) OnWelcome(e *irc.Event) {
 	// execute puppet prejoin commands
 	err := i.manager.varys.SendRaw(i.discord.ID, varys.InterpolationParams{Nick: true}, i.manager.bridge.Config.IRCPuppetPrejoinCommands...)
@@ -39,6 +51,9 @@ func (i *ircConnection) OnWelcome(e *irc.Event) {
 	}
 
 	i.JoinChannels()
+
+	// just in case NickServ, Q:Lines, or otherwise force our nick to be not what we expect!
+	i.manager.puppetNicks[i.GetNick()] = i
 
 	go func(i *ircConnection) {
 		for m := range i.messages {

--- a/bridge/irc_connection.go
+++ b/bridge/irc_connection.go
@@ -32,12 +32,18 @@ type ircConnection struct {
 }
 
 func (i *ircConnection) GetNick() string {
-	nick, _ := i.manager.varys.GetNick(i.discord.ID)
+	nick, err := i.manager.varys.GetNick(i.discord.ID)
+	if err != nil {
+		panic(err.Error())
+	}
 	return nick
 }
 
 func (i *ircConnection) Connected() bool {
-	connected, _ := i.manager.varys.Connected(i.discord.ID)
+	connected, err := i.manager.varys.Connected(i.discord._ID)
+	if err != nil {
+		panic(err.Error())
+	}
 	return connected
 }
 

--- a/bridge/irc_connection.go
+++ b/bridge/irc_connection.go
@@ -32,15 +32,13 @@ type ircConnection struct {
 }
 
 func (i *ircConnection) GetNick() string {
-	var nick varys.GetNickParams
-	_ = i.manager.varys.GetNick(i.discord.ID, &nick)
-	return nick.Nick
+	nick, _ := i.manager.varys.GetNick(i.discord.ID)
+	return nick
 }
 
 func (i *ircConnection) Connected() bool {
-	var connected varys.ConnectedParams
-	_ = i.manager.varys.Connected(i.discord.ID, &connected)
-	return connected.Connected
+	connected, _ := i.manager.varys.Connected(i.discord.ID)
+	return connected
 }
 
 func (i *ircConnection) OnWelcome(e *irc.Event) {

--- a/bridge/irc_connection.go
+++ b/bridge/irc_connection.go
@@ -40,7 +40,7 @@ func (i *ircConnection) GetNick() string {
 }
 
 func (i *ircConnection) Connected() bool {
-	connected, err := i.manager.varys.Connected(i.discord._ID)
+	connected, err := i.manager.varys.Connected(i.discord.ID)
 	if err != nil {
 		panic(err.Error())
 	}

--- a/bridge/irc_connection.go
+++ b/bridge/irc_connection.go
@@ -32,15 +32,15 @@ type ircConnection struct {
 }
 
 func (i *ircConnection) GetNick() string {
-	var nick string
+	var nick varys.GetNickParams
 	i.manager.varys.GetNick(i.discord.ID, &nick)
-	return nick
+	return nick.Nick
 }
 
 func (i *ircConnection) Connected() bool {
-	var connected bool
+	var connected varys.ConnectedParams
 	i.manager.varys.Connected(i.discord.ID, &connected)
-	return connected
+	return connected.Connected
 }
 
 func (i *ircConnection) OnWelcome(e *irc.Event) {

--- a/bridge/irc_listener.go
+++ b/bridge/irc_listener.go
@@ -17,7 +17,7 @@ type ircListener struct {
 
 func newIRCListener(dib *Bridge, webIRCPass string) *ircListener {
 	irccon := irc.IRC(dib.Config.IRCListenerName, "discord")
-	listener := &ircListener{irccon, dib, nil}
+	listener := &ircListener{irccon, dib, make(map[string]int)}
 
 	dib.SetupIRCConnection(irccon, "discord.", "fd75:f5f5:226f::")
 	listener.SetDebugMode(dib.Config.Debug)

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/matterbridge/discordgo v0.23.2-0.20210201201054-fb39a175b4f7
 	github.com/mozillazg/go-unidecode v0.1.1
 	github.com/pkg/errors v0.9.1
-	github.com/qaisjp/go-ircevent v0.0.0-20210223011734-62863beddc83
+	github.com/qaisjp/go-ircevent v0.0.0-20210224154625-07452bfb05b5
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -709,8 +709,8 @@ github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+Gx
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.2.0/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
-github.com/qaisjp/go-ircevent v0.0.0-20210223011734-62863beddc83 h1:SiuWjeNwlX3XwKDbO5nA77tkP19TiUWu4fkVzMxmZKQ=
-github.com/qaisjp/go-ircevent v0.0.0-20210223011734-62863beddc83/go.mod h1:QVUXUOAPFwMwEh+GKC+Zh56c5p7tZpRqGbXZzqaWbZE=
+github.com/qaisjp/go-ircevent v0.0.0-20210224154625-07452bfb05b5 h1:elH75Fsz3q1CQT3/dt55EuehXGTBK/rslX7qnLvxADg=
+github.com/qaisjp/go-ircevent v0.0.0-20210224154625-07452bfb05b5/go.mod h1:QVUXUOAPFwMwEh+GKC+Zh56c5p7tZpRqGbXZzqaWbZE=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/reflog/dateconstraints v0.2.1/go.mod h1:Ax8AxTBcJc3E/oVS2hd2j7RDM/5MDtuPwuR7lIHtPLo=

--- a/irc/varys/client_mem.go
+++ b/irc/varys/client_mem.go
@@ -34,14 +34,12 @@ func (c *memClient) Nick(uid string, nick string) error {
 	return c.varys.Nick(NickParams{uid, nick}, nil)
 }
 
-func (c *memClient) GetNick(uid string) (string, error) {
-	var nick string
-	err := c.varys.GetNick(uid, &nick)
-	return nick, err
+func (c *memClient) GetNick(uid string) (result string, err error) {
+	err = c.varys.GetNick(uid, &result)
+	return
 }
 
-func (c *memClient) Connected(uid string) (bool, error) {
-	var connected bool
-	err := c.varys.Connected(uid, &connected)
-	return connected, err
+func (c *memClient) Connected(uid string) (result bool, err error) {
+	err = c.varys.Connected(uid, &result)
+	return
 }

--- a/irc/varys/client_mem.go
+++ b/irc/varys/client_mem.go
@@ -34,10 +34,14 @@ func (c *memClient) Nick(uid string, nick string) error {
 	return c.varys.Nick(NickParams{uid, nick}, nil)
 }
 
-func (c *memClient) GetNick(uid string, nick *GetNickParams) error {
-	return c.varys.GetNick(uid, nick)
+func (c *memClient) GetNick(uid string) (string, error) {
+	var nick string
+	err := c.varys.GetNick(uid, &nick)
+	return nick, err
 }
 
-func (c *memClient) Connected(uid string, connected *ConnectedParams) error {
-	return c.varys.Connected(uid, connected)
+func (c *memClient) Connected(uid string) (bool, error) {
+	var connected bool
+	err := c.varys.Connected(uid, &connected)
+	return connected, err
 }

--- a/irc/varys/client_mem.go
+++ b/irc/varys/client_mem.go
@@ -33,3 +33,11 @@ func (c *memClient) SendRaw(uid string, params InterpolationParams, messages ...
 func (c *memClient) Nick(uid string, nick string) error {
 	return c.varys.Nick(NickParams{uid, nick}, nil)
 }
+
+func (c *memClient) GetNick(uid string, nick *string) error {
+	return c.varys.GetNick(uid, nick)
+}
+
+func (c *memClient) Connected(uid string, connected *bool) error {
+	return c.varys.Connected(uid, connected)
+}

--- a/irc/varys/client_mem.go
+++ b/irc/varys/client_mem.go
@@ -34,10 +34,10 @@ func (c *memClient) Nick(uid string, nick string) error {
 	return c.varys.Nick(NickParams{uid, nick}, nil)
 }
 
-func (c *memClient) GetNick(uid string, nick *string) error {
+func (c *memClient) GetNick(uid string, nick *GetNickParams) error {
 	return c.varys.GetNick(uid, nick)
 }
 
-func (c *memClient) Connected(uid string, connected *bool) error {
+func (c *memClient) Connected(uid string, connected *ConnectedParams) error {
 	return c.varys.Connected(uid, connected)
 }

--- a/irc/varys/client_net.go
+++ b/irc/varys/client_net.go
@@ -48,10 +48,14 @@ func (c *netClient) Nick(uid string, nick string) error {
 	return c.client.Call("Varys.Nick", NickParams{uid, nick}, &reply)
 }
 
-func (c *netClient) GetNick(uid string, nick *GetNickParams) error {
-	return c.client.Call("Varys.GetNick", uid, nick)
+func (c *netClient) GetNick(uid string) (string, error) {
+	var nick string
+	err := c.client.Call("Varys.GetNick", uid, &nick)
+	return nick, err
 }
 
-func (c *netClient) Connected(uid string, connected *ConnectedParams) error {
-	return c.client.Call("Varys.GetNick", uid, connected)
+func (c *netClient) Connected(uid string) (bool, error) {
+	var connected bool
+	err := c.client.Call("Varys.GetNick", uid, &connected)
+	return connected, err
 }

--- a/irc/varys/client_net.go
+++ b/irc/varys/client_net.go
@@ -48,10 +48,10 @@ func (c *netClient) Nick(uid string, nick string) error {
 	return c.client.Call("Varys.Nick", NickParams{uid, nick}, &reply)
 }
 
-func (c *netClient) GetNick(uid string, nick *string) error {
+func (c *netClient) GetNick(uid string, nick *GetNickParams) error {
 	return c.client.Call("Varys.GetNick", uid, nick)
 }
 
-func (c *netClient) Connected(uid string, connected *bool) error {
+func (c *netClient) Connected(uid string, connected *ConnectedParams) error {
 	return c.client.Call("Varys.GetNick", uid, connected)
 }

--- a/irc/varys/client_net.go
+++ b/irc/varys/client_net.go
@@ -47,3 +47,11 @@ func (c *netClient) Nick(uid string, nick string) error {
 	var reply struct{}
 	return c.client.Call("Varys.Nick", NickParams{uid, nick}, &reply)
 }
+
+func (c *netClient) GetNick(uid string, nick *string) error {
+	return c.client.Call("Varys.GetNick", uid, nick)
+}
+
+func (c *netClient) Connected(uid string, connected *bool) error {
+	return c.client.Call("Varys.GetNick", uid, connected)
+}

--- a/irc/varys/client_net.go
+++ b/irc/varys/client_net.go
@@ -48,14 +48,12 @@ func (c *netClient) Nick(uid string, nick string) error {
 	return c.client.Call("Varys.Nick", NickParams{uid, nick}, &reply)
 }
 
-func (c *netClient) GetNick(uid string) (string, error) {
-	var nick string
-	err := c.client.Call("Varys.GetNick", uid, &nick)
-	return nick, err
+func (c *netClient) GetNick(uid string) (result string, err error) {
+	err = c.client.Call("Varys.GetNick", uid, &result)
+	return
 }
 
-func (c *netClient) Connected(uid string) (bool, error) {
-	var connected bool
-	err := c.client.Call("Varys.GetNick", uid, &connected)
-	return connected, err
+func (c *netClient) Connected(uid string) (result bool, err error) {
+	err = c.client.Call("Varys.GetNick", uid, &result)
+	return
 }

--- a/irc/varys/varys.go
+++ b/irc/varys/varys.go
@@ -44,9 +44,9 @@ type Client interface {
 	// SendRaw supports a blank uid to send to all connections.
 	SendRaw(uid string, params InterpolationParams, messages ...string) error
 	// GetNick gets the current connection's nick
-	GetNick(uid string, nick *GetNickParams) error
+	GetNick(uid string) (string, error)
 	// Connected returns the status of the current connection
-	Connected(uid string, connected *ConnectedParams) error
+	Connected(uid string) (bool, error)
 }
 
 type SetupParams struct {
@@ -164,13 +164,9 @@ func (v *Varys) SendRaw(params SendRawParams, _ *struct{}) error {
 	return nil
 }
 
-type GetNickParams struct {
-	Nick string
-}
-
-func (v *Varys) GetNick(uid string, nick *GetNickParams) error {
+func (v *Varys) GetNick(uid string, result *string) error {
 	if conn, ok := v.uidToConns[uid]; ok {
-		nick.Nick = conn.GetNick()
+		*result = conn.GetNick()
 	}
 	return nil
 }

--- a/irc/varys/varys.go
+++ b/irc/varys/varys.go
@@ -171,13 +171,9 @@ func (v *Varys) GetNick(uid string, result *string) error {
 	return nil
 }
 
-type ConnectedParams struct {
-	Connected bool
-}
-
-func (v *Varys) Connected(uid string, connected *ConnectedParams) error {
+func (v *Varys) Connected(uid string, result *bool) error {
 	if conn, ok := v.uidToConns[uid]; ok {
-		connected.Connected = conn.Connected()
+		*result = conn.Connected()
 	}
 
 	return nil

--- a/irc/varys/varys.go
+++ b/irc/varys/varys.go
@@ -44,9 +44,9 @@ type Client interface {
 	// SendRaw supports a blank uid to send to all connections.
 	SendRaw(uid string, params InterpolationParams, messages ...string) error
 	// GetNick gets the current connection's nick
-	GetNick(uid string, nick *string) error
+	GetNick(uid string, nick *GetNickParams) error
 	// Connected returns the status of the current connection
-	Connected(uid string, connected *bool) error
+	Connected(uid string, connected *ConnectedParams) error
 }
 
 type SetupParams struct {
@@ -164,22 +164,26 @@ func (v *Varys) SendRaw(params SendRawParams, _ *struct{}) error {
 	return nil
 }
 
-func (v *Varys) GetNick(uid string, nick *string) error {
-	ret := ""
+type GetNickParams struct {
+	Nick string
+}
+
+func (v *Varys) GetNick(uid string, nick *GetNickParams) error {
 	if conn, ok := v.uidToConns[uid]; ok {
-		ret = conn.GetNick()
+		nick.Nick = conn.GetNick()
 	}
-	nick = &ret
 	return nil
 }
 
-func (v *Varys) Connected(uid string, connected *bool) error {
-	ret := false
+type ConnectedParams struct {
+	Connected bool
+}
+
+func (v *Varys) Connected(uid string, connected *ConnectedParams) error {
 	if conn, ok := v.uidToConns[uid]; ok {
-		ret = conn.Connected()
+		connected.Connected = conn.Connected()
 	}
 
-	connected = &ret
 	return nil
 }
 

--- a/irc/varys/varys.go
+++ b/irc/varys/varys.go
@@ -43,6 +43,10 @@ type Client interface {
 
 	// SendRaw supports a blank uid to send to all connections.
 	SendRaw(uid string, params InterpolationParams, messages ...string) error
+	// GetNick gets the current connection's nick
+	GetNick(uid string, nick *string) error
+	// Connected returns the status of the current connection
+	Connected(uid string, connected *bool) error
 }
 
 type SetupParams struct {
@@ -157,6 +161,25 @@ func (v *Varys) SendRaw(params SendRawParams, _ *struct{}) error {
 			c.SendRaw(msg)
 		}
 	})
+	return nil
+}
+
+func (v *Varys) GetNick(uid string, nick *string) error {
+	ret := ""
+	if conn, ok := v.uidToConns[uid]; ok {
+		ret = conn.GetNick()
+	}
+	nick = &ret
+	return nil
+}
+
+func (v *Varys) Connected(uid string, connected *bool) error {
+	ret := false
+	if conn, ok := v.uidToConns[uid]; ok {
+		ret = conn.Connected()
+	}
+
+	connected = &ret
 	return nil
 }
 


### PR DESCRIPTION
 Fix: Race conditions and execution order issues

* This should make use of the new features in go-ircevent so as to not
  cause panics from concurrent read & write to maps.

* This should also make it where we don't need to reimplement nick
  tracking in go-discord-irc by making use of go-ircevent's features to
  insure our callbacks are called after/before state tracking has
  occured.

* This should keep quits/kicks/parts from showing for puppeted nicks by
  maintaining correct order of execution for the corresponding events
  where we have more than one handler due to tracking puppets.

Most of this was separated out from #72. It is yet to be tested and is possible I'm doing RPC wrong (in which case please give me a pointer or 2).

**EDIT**:
Tested, NICK/PART/JOIN working - figuring out QUIT.

**EDIT 2**:
Tested, working completely (does require go.mod bump).