### PR TITLE
missing irc_server_name

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,6 +1,6 @@
 ---
 discord_token: abc.def.ghi
-irc_server_name: IRC
+irc_server_name: irc
 irc_server: localhost:6697
 guild_id: 315277951597936640
 nickserv_identify: password123

--- a/config.yml
+++ b/config.yml
@@ -1,5 +1,6 @@
 ---
 discord_token: abc.def.ghi
+irc_server_name: IRC
 irc_server: localhost:6697
 guild_id: 315277951597936640
 nickserv_identify: password123


### PR DESCRIPTION
FATA[0000] 'irc_server_name' config option is required and cannot be empty