### PR TITLE
Allow colour based spoilers on IRC

### DIFF
--- a/bridge/discord.go
+++ b/bridge/discord.go
@@ -89,6 +89,10 @@ func userToMention(u *discordgo.User) (mention string) {
 	return
 }
 
+// For spoiler colouring:
+var spoilerPattern = regexp.MustCompile(`\|\|(.*?)\|\|`)
+var colorCode = string(rune(3))
+
 func (d *discordBot) publishMessage(s *discordgo.Session, m *discordgo.Message, wasEdit bool) {
 	// Fix crash if these fields don't exist
 	if m.Author == nil || s.State.User == nil {
@@ -146,6 +150,10 @@ func (d *discordBot) publishMessage(s *discordgo.Session, m *discordgo.Message, 
 		}
 
 		content = "[edit] " + content
+	}
+
+	if strings.Count(content, "||") >= 2 {
+		content = spoilerPattern.ReplaceAllString(content, colorCode+"1,1$1"+colorCode)
 	}
 
 	pmTarget := ""

--- a/bridge/irc_listener.go
+++ b/bridge/irc_listener.go
@@ -262,7 +262,7 @@ func (i *ircListener) OnPrivateMessage(e *irc.Event) {
 		msg = "_" + msg + "_"
 	}
 
-	msg = ircf.BlocksToMarkdown(ircf.Parse(ircf.StripColor(msg)))
+	msg = ircf.BlocksToMarkdown(ircf.Parse(msg))
 
 	go func(e *irc.Event) {
 		i.bridge.discordMessagesChan <- IRCMessage{


### PR DESCRIPTION
In two parts:
1. Replace || delimited spoilers from discord with the black on black IRC colour codes. This is rendered as it is in discord, meaning that embedded || will break spoilers.
2. Remove colour stripping from the IRC->Discord side of the bridge, which enables spoiler detection to work.

Limitations:
* The receiving IRCd may opt to strip colour codes, leaving no indication of spoilers. This is somewhat mitigated by the fact that wrapping IRC text in `||` didn't actually hide it from view anyway.