### PR TITLE
Use AllowedMentions instead of manually disabling everyone pings

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -417,10 +417,6 @@ func (b *Bridge) loop() {
 				return "<" + emoji + ">"
 			})
 
-			// Replace everyone and here - https://git.io/Je1yi
-			content = strings.ReplaceAll(content, "@everyone", "@\u200beveryone")
-			content = strings.ReplaceAll(content, "@here", "@\u200bhere")
-
 			if username == "" {
 				// System messages come straight from the bot
 				if _, err := b.discord.Session.ChannelMessageSend(mapping.DiscordChannel, content); err != nil {
@@ -435,9 +431,16 @@ func (b *Bridge) loop() {
 					_, err := b.discord.transmitter.Send(
 						mapping.DiscordChannel,
 						&discordgo.WebhookParams{
-							Username:  username,
-							AvatarURL: avatar,
-							Content:   content,
+							Username:        username,
+							AvatarURL:       avatar,
+							Content:         content,
+							AllowedMentions: &discordgo.MessageAllowedMentions{
+								// Allow user and role mentions, but not everyone or here mentions
+								Parse: []discordgo.AllowedMentionType{
+									discordgo.AllowedMentionTypeRoles,
+									discordgo.AllowedMentionTypeUsers,
+								},
+							},
 						},
 					)
 


### PR DESCRIPTION
This PR switches how `go-discord-irc` disables `@everyone` and `@here` pings from manual text replacement to the webhook `AllowedMentions` option.

This is safer and more future-proof as it makes Discord responsible on the server-side for not parsing the pings, instead of performing flaky text replacement that can be broken if Discord changes the way it parses. (If Discord decides to strip all zero-width space for example, existing code will need to be changed to avoid pinging everyone). This PR should also lessens the maintainability burden in that regard.