### PR TITLE
Keep whitespace-only messages from IRC by wrapping with ZWS

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -397,9 +397,12 @@ func (b *Bridge) loop() {
 
 			content := msg.Message
 
-			// No content = zero width space
-			if content == "" {
-				content = "\u200B"
+			// If the message contains content or only whitespace, surround that with
+			// zero width spaces so that Discord displays them as intended. E.g. 3
+			// space characters sent from IRC should render on Discord as 3 space
+			// characters too.
+			if strings.TrimSpace(content) == "" {
+				content = "\u200B" + content + "\u200B"
 			}
 
 			// Convert any emoji ye?


### PR DESCRIPTION
This PR makes it so that IRC messages that are empty or containing only whitespaces are sent to Discord and displayed in the intended way. It is achieved by wrapping the message with Zero-Width Space characters.

The existing code sends an empty message properly if the IRC content was entirely empty. However, if for example the IRC message consisted of 4 spaces, the existing code would not catch these and would send it to Discord as-is. The Discord API does not allow sending whitespace-only messages, and thus those IRC messages were never relayed to Discord.

This behaviour is wanted since there are times when empty messages are intended, whether it be a joke or for formatting reasons, and the existing behaviour introduces inconsistencies on the Discord-side.