### PR TITLE
Fix whitespace-only IRC messages not being sent despite changes in #133

### DIFF
--- a/bridge/irc_listener.go
+++ b/bridge/irc_listener.go
@@ -242,8 +242,7 @@ func (i *ircListener) OnPrivateMessage(e *irc.Event) {
 		return
 	}
 
-	if strings.TrimSpace(e.Message()) == "" || // Discord doesn't accept an empty message
-		i.isPuppetNick(e.Nick) || // ignore msg's from our puppets
+	if i.isPuppetNick(e.Nick) || // ignore msg's from our puppets
 		i.bridge.ircManager.isIgnoredHostmask(e.Source) || //ignored hostmasks
 		i.bridge.ircManager.isFilteredIRCMessage(e.Message()) { // filtered
 		return


### PR DESCRIPTION
This PR removes a line in `irc_listener.go` that returns early and ignores all IRC messages that consists of only whitespace. This problematic line essentially voids the changes in #133, since no messages will satisfy the newly-added conditional. This also explains why the latest deployment of `master` still does not send empty messages from IRC->Discord.

The code was fine before, because we wanted to make sure no empty messages would be sent to Discord. Now that we have the ZWS-wrapping in `bridge.go` that enables us to send empty messages, this preemptive `return` is no longer necessary. 

You might be busy, but I hope you can take a look whenever you have the chance!