### PR TITLE
Surround IRC messages with ZWS for leading/trailing spaces too

### DIFF
--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -397,11 +397,12 @@ func (b *Bridge) loop() {
 
 			content := msg.Message
 
-			// If the message contains content or only whitespace, surround that with
-			// zero width spaces so that Discord displays them as intended. E.g. 3
-			// space characters sent from IRC should render on Discord as 3 space
-			// characters too.
-			if strings.TrimSpace(content) == "" {
+			// If the message has leading or trailing spaces, or if the message consists
+			// entirely of whitespace, we want Discord to display them as intended,
+			// rather than ignoring it. We surround the content with zero-width spaces
+			// to achieve this. For example, 3 space characters sent from IRC should
+			// render on Discord as 3 space characters too.
+			if strings.TrimSpace(content) != content {
 				content = "\u200B" + content + "\u200B"
 			}
 

--- a/bridge/bridge.go
+++ b/bridge/bridge.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gobwas/glob"
 	"github.com/bwmarrin/discordgo"
+	"github.com/gobwas/glob"
 	"github.com/pkg/errors"
 	"github.com/qaisjp/go-discord-irc/irc/varys"
 	irc "github.com/qaisjp/go-ircevent"
@@ -402,7 +402,7 @@ func (b *Bridge) loop() {
 			// rather than ignoring it. We surround the content with zero-width spaces
 			// to achieve this. For example, 3 space characters sent from IRC should
 			// render on Discord as 3 space characters too.
-			if strings.TrimSpace(content) != content {
+			if content == "" || strings.TrimSpace(content) != content {
 				content = "\u200B" + content + "\u200B"
 			}
 
@@ -435,9 +435,9 @@ func (b *Bridge) loop() {
 					_, err := b.discord.transmitter.Send(
 						mapping.DiscordChannel,
 						&discordgo.WebhookParams{
-							Username:        username,
-							AvatarURL:       avatar,
-							Content:         content,
+							Username:  username,
+							AvatarURL: avatar,
+							Content:   content,
 							AllowedMentions: &discordgo.MessageAllowedMentions{
 								// Allow user and role mentions, but not everyone or here mentions
 								Parse: []discordgo.AllowedMentionType{


### PR DESCRIPTION
Currently, with the changes in #133, we wrap whitespace-only IRC messages with zero-width spaces so that they render as intended on Discord. In the discussion of that pull request, @qaisjp mentioned it could be worth doing it to messages that have leading or trailing whitespace as well (https://github.com/qaisjp/go-discord-irc/pull/133#issuecomment-1214455761). This PR enables that.

Instead of comparing the output of `TrimSpace` to `""`, we compare it to the original string. This will only return `true` if there are leading/trailing spaces or the message consists entirely of whitespace. This will now no longer catch messages that are *empty*, so we add a new conditional clause for that.

This change will allow users to use whitespace to indent code, or write ASCII art, or perform other creative things with the full expectation that it will display as intended on both fellow IRC clients and Discord clients. This improves accessibility and I don't see any drawbacks.

---

I also ran a `go fmt` on the code, which made some very very minor changes elsewhere.