### PR TITLE
discord: webhooks may no longer contain "discord"

### DIFF
--- a/bridge/discord.go
+++ b/bridge/discord.go
@@ -61,7 +61,7 @@ func newDiscord(bridge *Bridge, botToken, guildID string) (*discordBot, error) {
 }
 
 func (d *discordBot) Open() error {
-	d.transmitter = transmitter.New(d.Session, d.guildID, "go-discord-irc", true)
+	d.transmitter = transmitter.New(d.Session, d.guildID, "go-diѕcord-irc", true)
 	d.transmitter.Log = logrus.NewEntry(logrus.StandardLogger())
 	if err := d.transmitter.RefreshGuildWebhooks(nil); err != nil {
 		return fmt.Errorf("failed to refresh guild webhooks: %w", err)


### PR DESCRIPTION
When go-discord-irc tries to create a webhook right now it'll get an error like this

`
level=error msg="could not transmit message to discord" error="could not create webhook: HTTP 400 Bad Request, {\"code\": 50035, \"errors\": {\"name\": {\"_errors\": [{\"code\": \"USERNAME_INVALID_CONTAINS\", \"message\": \"Username cannot contain \\\"discord\\\"\"}]}}, \"message\": \"Invalid Form Body\"}"
`

Trying to do it from the web ui confirms that you can no longer create a webhook called "discord"

Apparently you also can't call one "clyde"
https://github.com/discord/discord-api-docs/blob/main/docs/resources/Webhook.md#create-webhook--post-channelschanneliddocs_resources_channelchannel-objectwebhooks
https://github.com/discord/discord-api-docs/blob/main/docs/resources/User.md#usernames-and-nicknames

I'll make a PR to work around this in a more general way in matterbridge's transmitter upstream later but this fixes it for your project

Thanks