### PR TITLE
Makefile: Fix go build argument

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ release: $(RELEASE_ZIP) ## Package release artifact
 
 $(BINARY): dep
 	@echo "🍳 Building $(BINARY)"
-	go build -i -v -o $(BINARY) -ldflags "-X main.version=$(GIT_TAG)-$(GIT_BRANCH).$(GIT_COMMIT)" $(BINARY_PKG_BUILD)
+	go build -v -o $(BINARY) -ldflags "-X main.version=$(GIT_TAG)-$(GIT_BRANCH).$(GIT_COMMIT)" $(BINARY_PKG_BUILD)
 
 $(RELEASE_ZIP): $(BINARY)
 	@echo "🍳 Building $(RELEASE_ZIP)"


### PR DESCRIPTION
# Goal

- Remove `-i` flag from Go build in Makefile

# Information

Since Go 1.17, `-i` flag [is deprecated](https://github.com/golang/go/issues/41696)