### PR TITLE
Properly bridge Discord embeds to IRC

### DIFF
--- a/bridge/discord.go
+++ b/bridge/discord.go
@@ -136,12 +136,12 @@ func (d *discordBot) publishMessage(s *discordgo.Session, m *discordgo.Message, 
 
 	// The content is an action if it matches "_(.+)_"
 	isAction := len(content) > 2 &&
-		m.Content[0] == '_' &&
-		m.Content[len(content)-1] == '_'
+		content[0] == '_' &&
+		content[len(content)-1] == '_'
 
 	// If it is an action, remove the enclosing underscores
 	if isAction {
-		content = content[1 : len(m.Content)-1]
+		content = content[1 : len(content)-1]
 	}
 
 	if wasEdit {
@@ -262,6 +262,28 @@ var emoteRegex = regexp.MustCompile(`<a?(:\w+:)\d+>`)
 func (d *discordBot) ParseText(m *discordgo.Message) string {
 	// Replace @user mentions with name~d mentions
 	content := m.Content
+
+	// Convert embeds to plaintext
+	for _, embed := range m.Embeds {
+		if embed.Title != "" {
+			content += fmt.Sprintf("--- %s\n", embed.Title)
+		}
+		if embed.Description != "" {
+			content += fmt.Sprintf("%s\n", embed.Description)
+		}
+		if embed.Footer != nil && embed.Footer.Text != "" {
+			content += fmt.Sprintf("%s\n", embed.Footer.Text)
+		}
+		if embed.Author != nil && embed.Author.Name != "" {
+			content += fmt.Sprintf("Author: %s\n", embed.Author.Name)
+		}
+		if embed.URL != "" {
+			content += fmt.Sprintf("URL: %s\n", embed.URL)
+		}
+		if embed.Timestamp != "" {
+			content += fmt.Sprintf("Timestamp: %s\n", embed.Timestamp)
+		}
+	}
 
 	for _, user := range m.Mentions {
 		// Find the irc username with the discord ID in irc connections


### PR DESCRIPTION
This discord embed:

![image](https://user-images.githubusercontent.com/4183876/225456032-78ae369a-7f86-4015-8d42-fdbe9279433c.png)

Turns into these IRC messages (username looks messed up because of windows terminal):

![image](https://user-images.githubusercontent.com/4183876/225456246-bbb3096f-6f29-458f-b6ea-d2b57414253c.png)

This also has a small change to how actions are corrected for, as otherwise it would panic when the message content was empty but the generated content wasn't (as is often the case for embeds).